### PR TITLE
fix：printf buffer reads repeatedly

### DIFF
--- a/stdio-common/printf.c
+++ b/stdio-common/printf.c
@@ -32,7 +32,8 @@ __printf (const char *format, ...)
   va_start (arg, format);
   done = __vfprintf_internal (stdout, format, arg, 0);
   va_end (arg);
-
+  fflush(stdout);
+   
   return done;
 }
 


### PR DESCRIPTION
Fix, buffer repeated read issue.
just like:
double s = 10;
printf("%.10f\n",s);
printf("%.10f\n",0);
All of results is the value of s.