### PR TITLE
Allow clone3 to fallback to clone2 upon EPERM

### DIFF
--- a/sysdeps/unix/sysv/linux/clone-internal.c
+++ b/sysdeps/unix/sysv/linux/clone-internal.c
@@ -80,7 +80,7 @@ __clone3_internal (struct clone_args *cl_args, int (*func) (void *args),
   if (atomic_load_relaxed (&clone3_supported) == 1)
     {
       int ret = __clone3 (cl_args, sizeof (*cl_args), func, arg);
-      if (ret != -1 || errno != ENOSYS)
+      if (ret != -1 || errno != ENOSYS || errno != EPERM)
 	return ret;
 
       atomic_store_relaxed (&clone3_supported, 0);
@@ -98,7 +98,7 @@ __clone_internal (struct clone_args *cl_args,
 #ifdef HAVE_CLONE3_WRAPPER
   int saved_errno = errno;
   int ret = __clone3_internal (cl_args, func, arg);
-  if (ret != -1 || errno != ENOSYS)
+  if (ret != -1 || errno != ENOSYS || errno != EPERM)
     return ret;
 
   /* NB: Restore errno since errno may be checked against non-zero


### PR DESCRIPTION
This is for compatibility with old Docker and old Host OS that have seccomp profiles that return EPERM instead of the expected ENOSYS.